### PR TITLE
More build fixes.

### DIFF
--- a/POKITTO_LIBS/ImageFormat/ImageFormat.h
+++ b/POKITTO_LIBS/ImageFormat/ImageFormat.h
@@ -19,15 +19,13 @@
 /**************************************************************************/
 
 #ifndef IMAGE_FORMAT_H
+#define IMAGE_FORMAT_H
 
 #define POK_TRACE(str) printf("%s (%d): %s", __FILE__, __LINE__,str)
 
 extern int openImageFileFromSD(char*, uint16_t **, uint8_t **);
 extern int directDrawImageFileFromSD(int16_t /*sx*/, int16_t /*sy*/, char* /*filepath*/);
 extern int directDrawImageFileFromSD(uint16_t /*ix*/, uint16_t /*iy*/, uint16_t /*iw*/, uint16_t /*ih*/, int16_t /*sx*/, int16_t /*sy*/, char* /*filepath*/);
-
-#define IMAGE_FORMAT_H
-
 
 #ifndef boolean
 //typedef bool boolean;

--- a/POKITTO_LIBS/ImageFormat/defines_linux_SIM.h
+++ b/POKITTO_LIBS/ImageFormat/defines_linux_SIM.h
@@ -1,3 +1,6 @@
+#ifndef DEFINES_LINUX_SIM_H
+#define DEFINES_LINUX_SIM_H
+
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -11,7 +14,7 @@
 
 #include <ctype.h>
 
-char* _strupr( char* s )
+inline char* _strupr( char* s )
   {
   char* p = s;
   while (*p = toupper( *p )) p++;
@@ -53,6 +56,4 @@ typedef struct tagBITMAPINFO {
   RGBQUAD          bmiColors[1];
 } __attribute__((packed)) BITMAPINFO, *PBITMAPINFO;
 
-RGBQUAD myColors[257];
-
-
+#endif // DEFINES_LINUX_SIM_H

--- a/POKITTO_LIBS/ImageFormat/defines_win_SIM.h
+++ b/POKITTO_LIBS/ImageFormat/defines_win_SIM.h
@@ -1,6 +1,11 @@
+#ifndef DEFINES_WIN_SIM_H
+#define DEFINES_WIN_SIM_H
+
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include "windows.h"
 #include <stdint.h>
+
+#endif // DEFINES_WIN_SIM_H


### PR DESCRIPTION
Add include guards for headers. Remove unused color table from header, this
needs to go to a cpp file. Make compat method inline to fix redeclaration
error, but also this should be better defined in a cpp module.