### PR TITLE
Fixed compiler warnings

### DIFF
--- a/POKITTO_CORE/PokittoCore.cpp
+++ b/POKITTO_CORE/PokittoCore.cpp
@@ -184,7 +184,7 @@ void Core::initDisplay() {
 void Core::showLogo() {
     uint32_t now;
     uint8_t state=0; //jump directly to logo, bypass teeth
-    uint16_t counter=0, i=0;
+    uint16_t i=0;
     uint16_t sc;
     while (state < 255/6) {
     now=getTime();

--- a/POKITTO_CORE/PokittoCore.cpp
+++ b/POKITTO_CORE/PokittoCore.cpp
@@ -456,7 +456,6 @@ char* Core::filemenu(char *ext) {
 			display.cursorX = 0;
 			display.cursorY = currentY;
 			display.textWrap = false;
-			uint16_t fc,bc;
 			fc = display.color;
             bc = display.bgcolor;
             //getFirstFile(ext);

--- a/POKITTO_LIBS/FileIO/FileIO_SIM.cpp
+++ b/POKITTO_LIBS/FileIO/FileIO_SIM.cpp
@@ -119,7 +119,7 @@ char* getCurrentFileName (){
 }
 
 
-char* getNextFile (char* ext){
+char* getNextFile (const char* ext){
 
     if (!diropened) pokInitSD();
 	int a=1;
@@ -138,7 +138,7 @@ char* getNextFile() {
     return getNextFile("");
 }
 
-char* getFirstFile(char* ext) {
+char* getFirstFile(const char* ext) {
     if (diropened) {
         tinydir_close(&tinydir);
         diropened=false;

--- a/Pokitto_settings.h
+++ b/Pokitto_settings.h
@@ -163,6 +163,9 @@
 /** SCREENMODE - USE THIS SELECTION FOR YOUR PROJECT **/
 
 #ifndef PROJ_SCREENMODE
+	#ifdef POK_COLORDEPTH
+		#undef POK_COLORDEPTH
+	#endif
     #ifdef PROJ_HIRES
         #if PROJ_HIRES > 0
             #define POK_SCREENMODE MODE_HI_4COLOR


### PR DESCRIPTION
Upon seeing the long list of warnings produced by this library as reported by spinal in [this thread](https://talk.pokitto.com/t/wiki-pokittosim-install-and-use/283/18), I decided to have a go at eliminating a few.

I don't currently have the facility to check that I haven't broken anything accidentally or indeed that I've actually fixed the warnings properly, but I was cautious and I believe my edits should have eliminated the warnings without side effects.
I hope to test it when I am in a position to do so, but if someone else is available to test it before then it would be much appreciated.

I have considered elimintating more of the warnings but I haven't yet familiarised myself with the style rules for editing the library. For example, I did not know which fix would be more suitable for eliminating the 'no return from non-void function' warnings:

* `return nullptr`;
* `return NULL`;
* `return ""`;
* `return someEmptyBuffer`;

I also was uncertain about whether the sign of `filelen` was significant (e.g. whether `-1` is a valid value that indicates something special) and whether the ambiguous comparison in `POKITTO_CORE\PokittoSounde.cpp` at line 212 should cast the unsigned value to a signed value or the signed value to an unsigned value.